### PR TITLE
[ZSQ][E02_04] Create Query Index and Exports

### DIFF
--- a/libs/zrocket-contracts/src/queries/README.md
+++ b/libs/zrocket-contracts/src/queries/README.md
@@ -131,13 +131,109 @@ See `../auth/index.ts` for the complete `JwtPayload` definition.
 - [ZRocket Synced Queries PRD](../../../docs/projects/zrocket-synced-queries/PRD.md)
 - [JWT Payload Types](../auth/index.ts)
 
-## Future Query Definitions
+## Available Query Definitions
 
-The following synced queries will be added in subsequent tasks:
+All query definitions are exported through a centralized index for easy importing:
 
-- **E02_01**: Public channel queries (`publicChannels`, `channelById`)
-- **E02_02**: Private room queries (`myChats`, `myGroups`, `chatById`, `groupById`)
-- **E02_03**: Message queries (`roomMessages`, `roomSystemMessages`, `searchMessages`)
-- **E02_04**: Query index and exports
+### Import Examples
 
-See [Epic E02 Stories](../../../docs/projects/zrocket-synced-queries/EPICS_AND_STORIES.md#zsqe02-query-definitions-and-client-integration) for details.
+```typescript
+// Import all queries from a single entry point
+import { 
+  // Context types and guards
+  QueryContext,
+  isAuthenticated,
+  
+  // Public channel queries (no authentication required)
+  publicChannels, 
+  channelById,
+  
+  // Private room queries (authentication required)
+  myChats, 
+  myGroups,
+  myRooms,
+  chatById,
+  groupById,
+  
+  // Message queries (permission-based)
+  roomMessages,
+  roomSystemMessages,
+  searchMessages,
+  
+  // Enums
+  RoomType 
+} from '@cbnsndwch/zrocket-contracts/queries';
+```
+
+### Usage in React Components
+
+```typescript
+import { useQuery } from '@rocicorp/zero/react';
+import { 
+  publicChannels, 
+  myChats, 
+  roomMessages, 
+  RoomType 
+} from '@cbnsndwch/zrocket-contracts/queries';
+
+function ChannelsList() {
+  // Public channels - no authentication required
+  const [channels] = useQuery(publicChannels());
+  return (
+    <div>
+      {channels.map(ch => (
+        <div key={ch._id}>{ch.name}</div>
+      ))}
+    </div>
+  );
+}
+
+function ChatsList() {
+  // Private chats - authentication required
+  const [chats] = useQuery(myChats());
+  return (
+    <div>
+      {chats.map(chat => (
+        <div key={chat._id}>{chat.name}</div>
+      ))}
+    </div>
+  );
+}
+
+function RoomMessages({ roomId }: { roomId: string }) {
+  // Room messages - permission-based
+  const [messages] = useQuery(
+    roomMessages(roomId, RoomType.PublicChannel, 100)
+  );
+  return (
+    <div>
+      {messages.map(msg => (
+        <div key={msg._id}>{msg.content}</div>
+      ))}
+    </div>
+  );
+}
+```
+
+### Query Catalog
+
+#### Public Channel Queries
+
+- ✅ **`publicChannels()`** - All public channels (no auth required)
+- ✅ **`channelById(channelId: string)`** - Specific channel with messages (no auth required)
+
+#### Private Room Queries
+
+- ✅ **`myChats()`** - User's direct message chats
+- ✅ **`myGroups()`** - User's private groups
+- ✅ **`myRooms()`** - User's chats (alias for myChats)
+- ✅ **`chatById(chatId: string)`** - Specific chat with messages (membership required)
+- ✅ **`groupById(groupId: string)`** - Specific group with messages (membership required)
+
+#### Message Queries
+
+- ✅ **`roomMessages(roomId, roomType, limit?)`** - User messages in a room
+- ✅ **`roomSystemMessages(roomId, roomType, limit?)`** - System messages in a room
+- ✅ **`searchMessages(query: string)`** - Search messages across accessible rooms
+
+See [Epic E02 Stories](../../../docs/projects/zrocket-synced-queries/EPICS_AND_STORIES.md#zsqe02-query-definitions-and-client-integration) for implementation details.

--- a/libs/zrocket-contracts/src/queries/channels.ts
+++ b/libs/zrocket-contracts/src/queries/channels.ts
@@ -1,0 +1,69 @@
+import { syncedQuery } from '@rocicorp/zero';
+import { z } from 'zod';
+
+import { builder } from '../schema/index.js';
+
+/**
+ * Query to retrieve all public channels.
+ *
+ * @remarks
+ * Public channels are accessible to all users, including anonymous users.
+ * This query does not require authentication.
+ *
+ * **Client-side**: Returns all public channels ordered by name
+ * **Server-side**: Returns all public channels (no permission filtering needed)
+ *
+ * @example
+ * ```typescript
+ * // In a React component:
+ * import { useQuery } from '@rocicorp/zero/react';
+ * import { publicChannels } from '@cbnsndwch/zrocket-contracts/queries';
+ *
+ * const [channels] = useQuery(publicChannels());
+ * ```
+ *
+ * @see {@link https://rocicorp.dev/docs/zero/synced-queries Zero Synced Queries}
+ */
+export const publicChannels = syncedQuery('publicChannels', z.tuple([]), () => {
+    // Public channels are accessible to everyone
+    return builder.channels.orderBy('name', 'asc');
+});
+
+/**
+ * Query to retrieve a specific public channel by ID.
+ *
+ * @param channelId - The ID of the channel to retrieve
+ *
+ * @remarks
+ * Public channels are accessible to all users, including anonymous users.
+ * This query does not require authentication.
+ *
+ * **Client-side**: Returns the channel with related messages if found
+ * **Server-side**: Returns the channel (no permission filtering needed)
+ *
+ * Includes up to 100 most recent user messages and system messages ordered by creation time.
+ *
+ * @example
+ * ```typescript
+ * // In a React component:
+ * import { useQuery } from '@rocicorp/zero/react';
+ * import { channelById } from '@cbnsndwch/zrocket-contracts/queries';
+ *
+ * const [channel] = useQuery(channelById(channelId));
+ * ```
+ *
+ * @see {@link https://rocicorp.dev/docs/zero/synced-queries Zero Synced Queries}
+ */
+export const channelById = syncedQuery(
+    'channelById',
+    z.tuple([z.string()]),
+    (channelId: string) => {
+        // Public channels are accessible to everyone
+        return builder.channels
+            .where('_id', '=', channelId)
+            .related('messages', q => q.orderBy('createdAt', 'desc').limit(100))
+            .related('systemMessages', q =>
+                q.orderBy('createdAt', 'desc').limit(100)
+            );
+    }
+);

--- a/libs/zrocket-contracts/src/queries/index.ts
+++ b/libs/zrocket-contracts/src/queries/index.ts
@@ -1,14 +1,52 @@
 /**
  * Zero synced query definitions for ZRocket.
  *
- * This module exports all synced queries for channels, rooms, and messages.
- * These queries enable server-side filtering and permission enforcement.
+ * This module provides a centralized export point for all synced queries,
+ * enabling server-side filtering and permission enforcement for channels,
+ * rooms (chats and groups), and messages.
  *
  * @module queries
+ *
+ * @example
+ * ```typescript
+ * // Import all queries from a single entry point
+ * import {
+ *   publicChannels,
+ *   channelById,
+ *   myChats,
+ *   myGroups,
+ *   roomMessages,
+ *   QueryContext,
+ *   isAuthenticated
+ * } from '@cbnsndwch/zrocket-contracts/queries';
+ *
+ * // Use in React components with useQuery hook
+ * import { useQuery } from '@rocicorp/zero/react';
+ *
+ * function ChannelsList() {
+ *   const [channels] = useQuery(publicChannels());
+ *   return <div>{channels.map(ch => <div key={ch._id}>{ch.name}</div>)}</div>;
+ * }
+ *
+ * function ChatsList() {
+ *   const [chats] = useQuery(myChats());
+ *   return <div>{chats.map(chat => <div key={chat._id}>{chat.name}</div>)}</div>;
+ * }
+ * ```
+ *
+ * @see {@link https://rocicorp.dev/docs/zero/synced-queries Zero Synced Queries Documentation}
  */
 
+// Query context and type guards
 export * from './context.js';
+
+// Public channel queries (no authentication required)
+export * from './channels.js';
+
+// Private room queries (authentication required)
 export * from './rooms.js';
+
+// Message queries (permission-based)
 export * from './messages.js';
 
 // Re-export RoomType for convenience in query usage


### PR DESCRIPTION
## Summary

This PR implements **Issue #73** - Create Query Index and Exports for centralized query access.

## Changes

### 1. Public Channel Queries (channels.ts)
- ✅ Created publicChannels() query - retrieves all public channels
- ✅ Created channelById(channelId) query - retrieves specific channel with messages
- Both queries use syncedQuery (no authentication required)

### 2. Centralized Query Index (index.ts)
- ✅ Organized exports by authentication requirements
- ✅ Added comprehensive JSDoc with usage examples
- ✅ Included inline code examples for React components
- ✅ Exports all query modules from single entry point

### 3. Documentation Updates (README.md)
- ✅ Replaced 'Future Query Definitions' with 'Available Query Definitions'
- ✅ Added comprehensive import examples
- ✅ Created complete query catalog with status checkmarks
- ✅ Added React component usage examples

## Testing

✅ Build: Successful  
✅ Format: All files formatted  
✅ Lint: Passed with no errors  
✅ Tests: All tests passing (113 passed, 75 skipped)

## Acceptance Criteria Met

- ✅ All exports available from centralized index: @cbnsndwch/zrocket-contracts/queries
- ✅ Clear, descriptive names with proper conventions
- ✅ TypeScript autocomplete works correctly
- ✅ No circular dependencies detected
- ✅ Documentation includes comprehensive examples

## Related Issues

Closes #73  
Part of Epic #62 - Query Definitions and Client Integration

## Next Steps

This completes the query definitions phase (E02_01-E02_04). The next tasks in Epic #62 are:
- E02_05: Update React Hooks for Channels (#74)
- E02_06: Update React Hooks for Private Rooms (#75)
- E02_07: Update React Hooks for Messages (#76)
- E02_08: Update Components Using Direct Queries (#77)